### PR TITLE
Properly map virtual path when useDisplayPaths = false

### DIFF
--- a/src/GoogleDriveAdapter.php
+++ b/src/GoogleDriveAdapter.php
@@ -1156,7 +1156,7 @@ class GoogleDriveAdapter implements FilesystemAdapter
             $result['display_path'] = $this->toDisplayPath($result['virtual_path']);
         } else {
             $result['virtual_path'] = ($dirname ? ($dirname.'/') : '').$id;
-            $result['display_path'] = $this->toDisplayPath($result['virtual_path']);
+            $result['display_path'] = $result['virtual_path'];
         }
 
         if ($type === 'file') {


### PR DESCRIPTION
There's currently no code difference in `normaliseObject()` when determining the virtual and display path.

When `useDisplayPaths = false`, this leads to unexpected behavior: `display_path` will be used as the `FileAttributes` "path" property while the configuration explicitly stated to not return display paths.

Example:
* `useDisplayPaths = false`
* list contents of a directory
* read the path of an item and use it to, for example, read last modification date
* the path is a display path, but the last modification date correctly assumes it'll be a virtual path, so an exception is thrown.

This simple code changes fixes that behavior.